### PR TITLE
Fix config imports

### DIFF
--- a/etl/scraper.py
+++ b/etl/scraper.py
@@ -29,8 +29,23 @@ class AIESECScraper:
         and loading necessary configurations.
         """
         self.session = requests.Session()
-        # Load configuration directly (or from config.py)
-        from config import BASE_URL, DEFAULT_VIEW_SUFFIX, REQUEST_DELAY_SECONDS, HEADERS
+        # Load configuration settings. We prefer a relative import so that the
+        # module works when executed as part of the package, but we also fall
+        # back to an absolute import when run directly.
+        try:
+            from .config import (
+                BASE_URL,
+                DEFAULT_VIEW_SUFFIX,
+                REQUEST_DELAY_SECONDS,
+                HEADERS,
+            )
+        except ImportError:  # pragma: no cover - fallback for direct execution
+            from config import (
+                BASE_URL,
+                DEFAULT_VIEW_SUFFIX,
+                REQUEST_DELAY_SECONDS,
+                HEADERS,
+            )
         self.base_url = BASE_URL
         self.view_suffix = DEFAULT_VIEW_SUFFIX
         self.delay = REQUEST_DELAY_SECONDS

--- a/etl/utils.py
+++ b/etl/utils.py
@@ -2,7 +2,16 @@ import pandas as pd
 import logging
 import os
 from typing import Dict, Optional # For type hints
-from config import COUNTRY_ID_COLUMN, COUNTRY_NAME_COLUMN
+# Use a relative import here so this module works whether the package is loaded
+# via its package name or executed directly. Importing "config" absolutely can
+# fail when the caller does not manipulate ``sys.path`` in the same way as the
+# development environment.
+# Prefer a relative import when used as part of the package but provide a
+# fallback to support running this module directly.
+try:
+    from .config import COUNTRY_ID_COLUMN, COUNTRY_NAME_COLUMN
+except ImportError:  # pragma: no cover - direct execution fallback
+    from config import COUNTRY_ID_COLUMN, COUNTRY_NAME_COLUMN
 
 # Basic logging configuration (can be moved to config.py or main.py for centralization)
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')


### PR DESCRIPTION
## Summary
- fix imports to use relative config
- add fallback to absolute imports for direct execution

## Testing
- `python -m py_compile etl/scraper.py etl/utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6842f2b43268832983be668f0686f10c